### PR TITLE
Feature/cleanup reading profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,5 @@ This document provides a summary of the differences between the KBV E-Rezept pro
 The results of the comparison can be viewed directly through these hosted links:
 - [KBV_PR_FOR_Organization in OrganizationDirectory](https://svensommer.github.io/structure_comparer/projects/erp/docs/OrganizationDirectory.html)
 - [KBV_PR_FOR_Practitioner in PractitionerDirectory](https://svensommer.github.io/structure_comparer/projects/erp/docs/PractitionerDirectory.html)
-- [KBV_PR_ERP_Prescription in epa-medication-request](https://svensommer.github.io/structure_comparer/projects/erp/docs/epa-medication-request.html)
-- [KBV_PR_ERP_Medication_Compounding, KBV_PR_ERP_Medication_FreeText, KBV_PR_ERP_Medication_Ingredient, KBV_PR_ERP_Medication_PZN in epa-medication](https://svensommer.github.io/structure_comparer/projects/erp/docs/epa-medication.html)
-
-
-
-
-
+- [KBV_PR_ERP_Prescription in EPAMedicationRequest](https://svensommer.github.io/structure_comparer/projects/erp/docs/EPAMedicationRequest.html)
+- [KBV_PR_ERP_Medication_Compounding, KBV_PR_ERP_Medication_FreeText, KBV_PR_ERP_Medication_Ingredient, KBV_PR_ERP_Medication_PZN in EPAMedication](https://svensommer.github.io/structure_comparer/projects/erp/docs/EPAMedication.html)

--- a/projects/erp/docs/EPAMedication.html
+++ b/projects/erp/docs/EPAMedication.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>Mapping: epa-medication</title>
+    <title>Mapping: EPAMedication</title>
     <link rel='stylesheet' type='text/css' href='./style.css'>
     <link rel='stylesheet' type='text/css' href='https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css'>
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.6.0.min.js'></script>
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-    <h2>Mapping: KBV_PR_ERP_Medication_Compounding, KBV_PR_ERP_Medication_FreeText, KBV_PR_ERP_Medication_Ingredient, KBV_PR_ERP_Medication_PZN in epa-medication</h2>
+    <h2>Mapping: KBV_PR_ERP_Medication_Compounding, KBV_PR_ERP_Medication_FreeText, KBV_PR_ERP_Medication_Ingredient, KBV_PR_ERP_Medication_PZN in EPAMedication</h2>
     <table id='resultsTable' class='display' style='width:100%'>
         <thead>
             <tr>
@@ -19,7 +19,7 @@
                 <th>KBV_PR_ERP_Medication_FreeText</th>
                 <th>KBV_PR_ERP_Medication_Ingredient</th>
                 <th>KBV_PR_ERP_Medication_PZN</th>
-                <th>epa-medication</th>
+                <th>EPAMedication</th>
                 <th>Remarks</th>
             </tr>
         </thead>

--- a/projects/erp/docs/EPAMedicationRequest.html
+++ b/projects/erp/docs/EPAMedicationRequest.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <title>Mapping: epa-medication-request</title>
+    <title>Mapping: EPAMedicationRequest</title>
     <link rel='stylesheet' type='text/css' href='./style.css'>
     <link rel='stylesheet' type='text/css' href='https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css'>
     <script type='text/javascript' src='https://code.jquery.com/jquery-3.6.0.min.js'></script>
@@ -10,13 +10,13 @@
 </head>
 
 <body>
-    <h2>Mapping: KBV_PR_ERP_Prescription in epa-medication-request</h2>
+    <h2>Mapping: KBV_PR_ERP_Prescription in EPAMedicationRequest</h2>
     <table id='resultsTable' class='display' style='width:100%'>
         <thead>
             <tr>
                 <th>Property</th>
                 <th>KBV_PR_ERP_Prescription</th>
-                <th>epa-medication-request</th>
+                <th>EPAMedicationRequest</th>
                 <th>Remarks</th>
             </tr>
         </thead>

--- a/projects/erp/manual_entries.json
+++ b/projects/erp/manual_entries.json
@@ -58,7 +58,7 @@
     "Medication.code.coding:pznCode.version": {
         "classification": "empty"
     },
-    "Medication.extension:RxPrescriptionProcessIdentifier<br>(https://gematik.de/fhir/epa-medication/StructureDefinition/rx-prescription-process-identifier-extension)": {
+    "Medication.extension:RxPrescriptionProcessIdentifier": {
         "classification": "medication_service"
     },
     "Medication.form.coding:kbvDarreichungsform": {
@@ -234,19 +234,19 @@
     "Practitioner.name:name": {
         "classification": "not_use"
     },
-    "Practitioner.name:name.family.extension:nachname<br>(http://hl7.org/fhir/StructureDefinition/humanname-own-name)": {
+    "Practitioner.name:name.family.extension:nachname": {
         "classification": "not_use"
     },
-    "Practitioner.name:name.family.extension:namenszusatz<br>(http://fhir.de/StructureDefinition/humanname-namenszusatz)": {
+    "Practitioner.name:name.family.extension:namenszusatz": {
         "classification": "not_use"
     },
-    "Practitioner.name:name.family.extension:vorsatzwort<br>(http://hl7.org/fhir/StructureDefinition/humanname-own-prefix)": {
+    "Practitioner.name:name.family.extension:vorsatzwort": {
         "classification": "not_use"
     },
     "Practitioner.name:name.family.value": {
         "classification": "not_use"
     },
-    "Practitioner.name:name.prefix.extension:prefix-qualifier<br>(http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier)": {
+    "Practitioner.name:name.prefix.extension:prefix-qualifier": {
         "classification": "not_use"
     },
     "Practitioner.name:name.prefix.value": {

--- a/projects/erp/mapping.json
+++ b/projects/erp/mapping.json
@@ -1,6 +1,6 @@
 {
     "KBV_PR_ERP_Medication_Compounding": {
-        "epa-medication": {
+        "EPAMedication": {
             "mappings": {
                 "Medication.amount": "Medication.amount",
                 "Medication.amount.numerator.extension:Gesamtmenge": "Medication.amount.numerator.extension:Gesamtmenge",
@@ -25,7 +25,7 @@
         }
     },
     "KBV_PR_ERP_Medication_FreeText": {
-        "epa-medication": {
+        "EPAMedication": {
             "mappings": {
                 "Medication.batch": "Medication.batch",
                 "Medication.code": "Medication.code",
@@ -41,7 +41,7 @@
         }
     },
     "KBV_PR_ERP_Medication_Ingredient": {
-        "epa-medication": {
+        "EPAMedication": {
             "mappings": {
                 "Medication.amount": "Medication.amount",
                 "Medication.amount.numerator.extension:Packungsgroesse": "Medication.amount.numerator.extension:Packungsgroesse",
@@ -62,7 +62,7 @@
         }
     },
     "KBV_PR_ERP_Medication_PZN": {
-        "epa-medication": {
+        "EPAMedication": {
             "mappings": {
                 "Medication.amount": "Medication.amount",
                 "Medication.amount.numerator.extension:Packungsgroesse": "Medication.amount.numerator.extension:Packungsgroesse",
@@ -111,7 +111,7 @@
         }
     },
     "KBV_PR_ERP_Prescription": {
-        "epa-medication-request": {
+        "EPAMedicationRequest": {
             "mappings": {
                 "MedicationRequest.authoredOn": "MedicationRequest.authoredOn",
                 "MedicationRequest.dispenseRequest": "MedicationRequest.dispenseRequest",

--- a/structure_comparer/compare.py
+++ b/structure_comparer/compare.py
@@ -1,9 +1,11 @@
-import json
+from collections import OrderedDict
+from pathlib import Path
 from typing import Dict, List
 import logging
 
 from .classification import Classification
 from .data.comparison import Comparison, ComparisonField, ProfileField
+from .data.profile import ProfileMap
 from .consts import REMARKS
 from .helpers import split_parent_child
 from .manual_entries import (
@@ -38,6 +40,9 @@ def compare_profiles(profiles_to_compare: List, datapath: Path):
     """
 
     profile_maps = _load_profiles(profiles_to_compare, datapath)
+    structured_results = _compare_profiles(profile_maps)
+
+    return structured_results
 
 
 def _load_profiles(profiles_to_compare: List, datapath: Path) -> Dict[str, ProfileMap]:
@@ -50,16 +55,70 @@ def _load_profiles(profiles_to_compare: List, datapath: Path) -> Dict[str, Profi
     }
     return profiles_maps
 
-    return presence_data
+
+def _compare_profiles(profile_maps: Dict[str, ProfileMap]) -> Dict[str, Comparison]:
+    """
+    Generate a structured representation containing the rules for each target profile.
+
+    The returned dictionary contains one item for each item in the argument `presence_data`. Each of these items
+    contains the names of KBV and ePA profiles, presence information for each of their fields and their
+    classifications and remarks.
+    """
+    mapping = {}
+    # Iterate over all mappings (each entry are mapping to the same profile)
+    for profiles, map in profile_maps.items():
+        comparison = Comparison()
+
+        key = str((tuple([entry.name for entry in map.sources]), map.target.name))
+        mapping[key] = comparison
+
+        # Generate the profile names
+        source_profiles = [profile.name for profile in map.sources]
+        target_profile = map.target.name
+
+        # Extract which profiles are KBV and which is the ePA one
+        comparison.source_profiles = source_profiles
+        comparison.target_profile = target_profile
+
+        for source_profile in [map.target] + map.sources:
+            for _, field in source_profile.fields.items():
+                # Check if field already exists or needs to be created
+                if (
+                    not (field_entry := comparison.fields.get(field.name))
+                    or field_entry.extension != field.extension
+                ):
+                    comparison.fields[field.name] = ComparisonField(field.name)
+                    comparison.fields[field.name].extension = field.extension
+
+                comparison.fields[field.name].profiles[source_profile.name] = (
+                    ProfileField(present=True)
+                )
+
+        # Sort the fields by name
+        comparison.fields = OrderedDict(
+            sorted(comparison.fields.items(), key=lambda x: x[0])
+        )
+
+        # Fill the absent profiles
+        all_profiles = source_profiles + [target_profile]
+        for field in comparison.fields.values():
+            for profile in all_profiles:
+                if profile not in field.profiles:
+                    field.profiles[profile] = ProfileField(present=False)
+
+        # Add remarks and classifications for each field
+        for field in comparison.fields.values():
+            _classify_remark_field(field, source_profiles, target_profile, comparison)
+
+    return mapping
 
 
-def _classify_remark_property(
-    comparison_field: ComparisonField,
-    prop: str,
-    kbv_presences: List[str],
-    epa_presence: str,
-    fields_updates: Dict[str, ComparisonField],
-) -> Dict[str, str]:
+def _classify_remark_field(
+    field: ComparisonField,
+    source_profiles: List[str],
+    target_profile: str,
+    comparison: Comparison,
+) -> None:
     """
     Classify and get the remark for the property
 
@@ -72,11 +131,11 @@ def _classify_remark_property(
     extra = None
 
     # Split the property in parent and child
-    parent, child = split_parent_child(prop)
+    parent, child = split_parent_child(field.name)
 
     # If there is a manual entry for this property, use it
-    if prop in MANUAL_ENTRIES:
-        manual_entry = MANUAL_ENTRIES[prop]
+    if field.name in MANUAL_ENTRIES:
+        manual_entry = MANUAL_ENTRIES[field.name]
         classification = manual_entry.get(
             MANUAL_ENTRIES_CLASSIFICATION, Classification.MANUAL
         )
@@ -95,7 +154,7 @@ def _classify_remark_property(
 
     # If the parent has a classification that can be derived use the parent's classification
     elif (
-        parent_update := fields_updates.get(parent)
+        parent_update := comparison.fields.get(parent)
     ) and parent_update.classification in DERIVED_CLASSIFICATIONS:
         classification = parent_update.classification
 
@@ -103,16 +162,16 @@ def _classify_remark_property(
         if classification in EXTRA_CLASSIFICATIONS:
 
             # Cut away the common part with the parent and add the remainer to the parents extra
-            extra = parent_update.extra + prop[len(parent) :]
+            extra = parent_update.extra + field.name[len(parent) :]
             remark = REMARKS[classification].format(extra)
 
         # Else use the parents remark
         else:
             remark = parent_update.remark
 
-    # If present in any of the KBV profiles
-    elif any(kbv_presences):
-        if epa_presence:
+    # If present in any of the source profiles
+    elif any([field.profiles[profile].present for profile in source_profiles]):
+        if field.profiles[target_profile].present:
             classification = Classification.USE
         else:
             classification = Classification.EXTENSION
@@ -122,72 +181,6 @@ def _classify_remark_property(
     if not remark:
         remark = REMARKS[classification]
 
-    comparison_field.classification = classification
-    comparison_field.remark = remark
-    comparison_field.extra = extra
-
-
-def _is_light_color(hex_color: str) -> bool:
-    r, g, b = int(hex_color[1:3], 16), int(hex_color[3:5], 16), int(hex_color[5:7], 16)
-    luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
-    return luminance > 0.5
-
-
-def _gen_structured_results(presence_data: dict) -> Comparison:
-    """
-    Generate a structured representation containing the rules for each target profile.
-
-    The returned dictionary contains one item for each item in the argument `presence_data`. Each of these items
-    contains the names of KBV and ePA profiles, presence information for each of their fields and their
-    classifications and remarks.
-    """
-    mapping = {}
-    # Iterate over all mappings (each entry are mapping to the same profile)
-    for profiles, presences in presence_data.items():
-        comparison = Comparison()
-
-        # Generate the profile names
-        source_profiles = [profile.replace(".json", "") for profile in profiles[0]]
-        target_profile = profiles[1].replace(".json", "")
-
-        # Extract which profiles are KBV and which is the ePA one
-        comparison.source_profiles = source_profiles
-        comparison.target_profile = target_profile
-
-        # Generate the mapping for all fields in those profiles
-        for field, field_presences in sorted(presences.items()):
-            field_update = ComparisonField()
-
-            field_updated = field
-            extension_url = None
-
-            # Get the field name while extracting the canonical for extensions
-            if "extension" in field and "<br>" in field:
-                field_updated, extension_url = field.split("<br>")
-                extension_url = extension_url.strip("()")
-            if extension_url:
-                field_update.extension = extension_url
-
-            # Extract the presences for KBV and ePA profiles
-            target_presence, source_presences = field_presences[0], field_presences[1:]
-            field_update.profiles[target_profile] = ProfileField(
-                present=target_presence
-            )
-            for profile, presence in zip(source_profiles, source_presences):
-                field_update.profiles[profile] = ProfileField(present=presence)
-
-            # Fill the classification and remark for this field
-            _classify_remark_property(
-                field_update,
-                field,
-                source_presences,
-                target_presence,
-                comparison.fields,
-            )
-
-            # Set the field update
-            comparison.fields[field_updated] = field_update
-
-        mapping[profiles] = comparison
-
-    return mapping
+    field.classification = classification
+    field.remark = remark
+    field.extra = extra

--- a/structure_comparer/data/__init__.py
+++ b/structure_comparer/data/__init__.py
@@ -1,1 +1,0 @@
-from .comparison import Comparison, ComparisonField, ProfileField

--- a/structure_comparer/data/comparison.py
+++ b/structure_comparer/data/comparison.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Dict, List
 
@@ -30,9 +31,9 @@ class ComparisonField:
 class Comparison:
     source_profiles: List[str]
     target_profile: str
-    fields: Dict[str, ComparisonField]
+    fields: OrderedDict[str, ComparisonField]
 
     def __init__(self) -> None:
         self.source_profiles = []
         self.target_profile = None
-        self.fields = {}
+        self.fields = OrderedDict()

--- a/structure_comparer/data/comparison.py
+++ b/structure_comparer/data/comparison.py
@@ -17,7 +17,8 @@ class ComparisonField:
     profiles: Dict[str, ProfileField]
     remark: str
 
-    def __init__(self) -> None:
+    def __init__(self, name: str) -> None:
+        self.name: str = name
         self.classification = None
         self.extension = None
         self.extra = None

--- a/structure_comparer/data/profile.py
+++ b/structure_comparer/data/profile.py
@@ -1,0 +1,138 @@
+from collections import OrderedDict
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+IGNORE_ENDS = ["id", "extension", "modifierExtension"]
+IGNORE_SLICES = [
+    "slice(url)",
+    "slice($this)",
+    "slice(system)",
+    "slice(type)",
+    "slice(use)",
+    # workaround for 'slice(code.coding.system)'
+    "system)",
+]
+
+
+class ProfileMap:
+    def __init__(self) -> None:
+        self.sources: List[Profile] = []
+        self.target: Profile = None
+
+    @staticmethod
+    def from_json(profiles_to_compare: List, datapath: Path) -> "ProfileMap":
+        sources = profiles_to_compare[0]
+        target = profiles_to_compare[1]
+
+        profiles_map = ProfileMap()
+        profiles_map.sources = [
+            Profile.from_json(datapath / source) for source in sources
+        ]
+        profiles_map.target = Profile.from_json(datapath / target)
+
+        return profiles_map
+
+
+class Profile:
+    def __init__(self, name: str) -> None:
+        self.name: str = name
+        self.fields: OrderedDict[str, ProfileField] = OrderedDict()
+
+    def __str__(self) -> str:
+        return f"(name={self.name}, fields={self.fields})"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    @staticmethod
+    def from_json(file: str | Path) -> "Profile":
+        if isinstance(file, str):
+            file = Path(file)
+
+        content = json.loads(file.read_text())
+
+        result = Profile(content["name"])
+
+        extracted_elements = _extract_elements(content["snapshot"]["element"])
+        result.fields = OrderedDict(
+            (field.name, field)
+            for field in sorted(extracted_elements, key=lambda x: x.name)
+        )
+
+        return result
+
+
+class ProfileField:
+    def __init__(self, name: str, extension: str = None) -> None:
+        self.name: str = name
+        self.extension: str = extension
+
+    def __str__(self) -> str:
+        return f"(name={self.name}{f', extension={self.extension}' if self.extension else ''})"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+def _extract_elements(elements: List[Dict]) -> List[ProfileField]:
+    result = []
+    ignore_paths = []
+
+    for element in elements:
+        path: str = element["id"]
+        path_split = path.split(".")
+
+        # Skip base element
+        if len(path_split) == 1:
+            continue
+
+        # Skip elements that are children of ignored nodes
+        if _should_ignore(path, ignore_paths):
+            continue
+
+        # Ignore elements with having specific path endings
+        if path_split[-1] in IGNORE_ENDS:
+            continue
+
+        # Ignore elements where the cardinality is set to zero
+        if element["max"] == "0" or element["max"] == 0:
+            # Extend list of nodes that are remove due cardinality
+            ignore_paths.append(path)
+            continue
+
+        # Check for specific extensions
+        if extension := _get_extension(element, path):
+            # Further ignore sub-elements of the extensions
+            ignore_paths.append(path)
+            result.append(extension)
+        else:
+            # Add the base path of the element
+            result.append(ProfileField(name=path))
+
+        # Check for and add slices, ignoring 'slice(url)' endings
+        if "slicing" in element and "discriminator" in element["slicing"]:
+            for discriminator in element["slicing"]["discriminator"]:
+                if isinstance(discriminator, dict) and "path" in discriminator:
+                    slice_path = f"{path}.slice({discriminator['path']})"
+                    slice_path_split = slice_path.split(".")
+                    if not slice_path_split[-1] in IGNORE_SLICES:
+                        result.append(ProfileField(name=slice_path))
+
+    return result
+
+
+def _should_ignore(path: str, ignore_paths: List[str]) -> bool:
+    for ignored in ignore_paths:
+        if path.startswith(ignored):
+            return True
+    return False
+
+
+def _get_extension(element: dict, path: str) -> str:
+    if "extension" in element and "type" in element:
+        for type_entry in element["type"]:
+            if type_entry.get("code") == "Extension" and "profile" in type_entry:
+                for profile in type_entry["profile"]:
+                    return ProfileField(name=path, extension=profile)

--- a/structure_comparer/results_dict.py
+++ b/structure_comparer/results_dict.py
@@ -2,7 +2,7 @@ import logging
 from typing import Dict
 
 from .classification import Classification
-from .data import Comparison
+from .data.comparison import Comparison
 from .consts import REMARKS
 from .helpers import split_parent_child
 

--- a/structure_comparer/results_html.py
+++ b/structure_comparer/results_html.py
@@ -7,7 +7,7 @@ from jinja2 import Environment, FileSystemLoader
 
 
 from .classification import Classification
-from .data import Comparison
+from .data.comparison import Comparison
 
 
 CSS_CLASS = {


### PR DESCRIPTION
# Überarbeitung Einlesen von Profilen und Vergleich

Um zukünftige Anpassungen zu vereinfachen wurden Zwischenschritte vereinfacht und die Anzahl der Iterationen verringert (die Ausführzeit ist hierdurch auch stark gesunken)

* Einlesen der Profile extrahiert und erfolgt nun in einer einzigen Iteration
* Zwischenschritte entfernt, nun nur noch
  *  Einlesen der Profile
  * Vergleich und Klassifikation

Die neue Einlesestruktur sollte es zukünftig auch leichter machen zusätzliche Informationen wie Kardinalitäten oder Typen zu erfassen.