### PR TITLE
added project loading

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,13 +33,13 @@
             ]
         },
         {
-            "name": "Flask App eRP",
+            "name": "Flask App",
             "type": "debugpy",
             "request": "launch",
             "program": "server.py",
             "args": [
-                "--project-dir",
-                "projects/erp"
+                "--projects-dir",
+                "./projects"
             ],
             "jinja": true,
             "justMyCode": true

--- a/frontend/structure-comparer/src/app/app-routing.module.ts
+++ b/frontend/structure-comparer/src/app/app-routing.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { MappingsListComponent } from './mappings-list/mappings-list.component'; // Pfad anpassen, falls nötig
+import { MappingsListComponent } from './mappings-list/mappings-list.component'; 
 import { MappingDetailComponent } from './mapping-detail/mapping-detail.component';
-
+import { ProjectListComponent } from './project-list/project-list.component'; 
 const routes: Routes = [
-  { path: '', redirectTo: '/mapping', pathMatch: 'full' },
+  { path: '', redirectTo: '/project', pathMatch: 'full' },
+  { path: 'project', component: ProjectListComponent },
   { path: 'mapping', component: MappingsListComponent }, 
   { path: 'mapping/:id', component: MappingDetailComponent },
 ];

--- a/frontend/structure-comparer/src/app/app.module.ts
+++ b/frontend/structure-comparer/src/app/app.module.ts
@@ -12,9 +12,10 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MappingsListComponent } from './mappings-list/mappings-list.component';
 import { HttpClientModule } from '@angular/common/http';
 import { MappingDetailComponent } from './mapping-detail/mapping-detail.component';
+import { ProjectListComponent } from './project-list/project-list.component';
 
 @NgModule({
-  declarations: [AppComponent, MappingsListComponent, MappingDetailComponent],
+  declarations: [AppComponent, MappingsListComponent, MappingDetailComponent, ProjectListComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/frontend/structure-comparer/src/app/project-list/project-list.component.css
+++ b/frontend/structure-comparer/src/app/project-list/project-list.component.css
@@ -1,0 +1,28 @@
+h2 {
+    color: #333;
+    margin-bottom: 15px;
+  }
+  
+  .project-list {
+    list-style-type: none;
+    padding: 0;
+  }
+  
+  .project-item {
+    margin-bottom: 10px;
+  }
+  
+  .project-link {
+    color: #007bff;
+    text-decoration: none;
+  }
+  
+  .project-link:hover, .project-link:focus {
+    text-decoration: underline;
+    color: #0056b3;
+  }
+  
+  p {
+    color: #666;
+  }
+  

--- a/frontend/structure-comparer/src/app/project-list/project-list.component.html
+++ b/frontend/structure-comparer/src/app/project-list/project-list.component.html
@@ -1,0 +1,6 @@
+<h2>Verfügbare Projekte</h2>
+<ul >
+  <li *ngFor="let project of projects" class="project-item">
+    <a (click)="loadProjectAndMappings(project)" class="project-link">{{ project }}</a>
+  </li>
+</ul>

--- a/frontend/structure-comparer/src/app/project-list/project-list.component.spec.ts
+++ b/frontend/structure-comparer/src/app/project-list/project-list.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectListComponent } from './project-list.component';
+
+describe('ProjectListComponent', () => {
+  let component: ProjectListComponent;
+  let fixture: ComponentFixture<ProjectListComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ProjectListComponent]
+    });
+    fixture = TestBed.createComponent(ProjectListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/structure-comparer/src/app/project-list/project-list.component.ts
+++ b/frontend/structure-comparer/src/app/project-list/project-list.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { ProjectService } from '../project.service';
+import { MappingsService } from '../mappings.service';
+
+@Component({
+  selector: 'app-project-list',
+  templateUrl: './project-list.component.html',
+  styleUrls: ['./project-list.component.css']
+})
+export class ProjectListComponent implements OnInit {
+  projects: any[] = [];
+
+  constructor(
+    private projectService: ProjectService, 
+    private mappingsService: MappingsService, 
+    private router: Router) { }  // Router hinzufügen
+
+  ngOnInit(): void {
+    this.projectService.getProjects().subscribe(data => {
+      this.projects = data;
+    });
+  }
+
+  loadProjectAndMappings(project: string): void {
+    this.projectService.loadProject(project).subscribe({
+      next: () => {
+        this.router.navigate(['/mapping']); // Navigation nach erfolgreicher Ladung
+      },
+      error: (error) => console.error('Error loading the project:', error)
+    });
+  }
+}

--- a/frontend/structure-comparer/src/app/project.service.spec.ts
+++ b/frontend/structure-comparer/src/app/project.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ProjectService } from './project.service';
+
+describe('ProjectService', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ProjectService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/structure-comparer/src/app/project.service.ts
+++ b/frontend/structure-comparer/src/app/project.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ProjectService {
+
+  private baseUrl = 'http://127.0.0.1:5000';
+
+  constructor(private http: HttpClient) { }
+
+  getProjects(): Observable<any> {
+    return this.http.get(`${this.baseUrl}/projects`)
+      .pipe(catchError(this.handleError));
+  }
+
+  loadProject(project: string): Observable<any> {
+    return this.http.post(`${this.baseUrl}/project/${project}/load`, 
+      {'project': project})
+      .pipe(catchError(this.handleError));
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    if (error.error instanceof ErrorEvent) {
+      console.error('An error occurred:', error.error.message);
+    } else {
+      console.error(
+        `Backend returned code ${error.status}, ` +
+        `body was: ${error.error}`);
+    }
+    return throwError(
+      'Something bad happened; please try again later.');
+  }
+}

--- a/rest/requests.http
+++ b/rest/requests.http
@@ -5,10 +5,29 @@ GET http://{{host}}
 
 ###
 
+# @name getprojects
+GET http://{{host}}/projects
+
+###
+
+@project_name = erp
+
+# @name loadproject
+POST http://{{host}}/project/{{project_name}}/load
+Content-Type: application/json
+
+{
+    "project_dir": "{{project_name}}"
+}
+
+###
+
 # @name spec
 GET http://{{host}}/spec
 
 ###
+
+@project_name = erp
 
 # @name getmappings
 GET http://{{host}}/mappings

--- a/rest/requests.http
+++ b/rest/requests.http
@@ -17,7 +17,7 @@ POST http://{{host}}/project/{{project_name}}/load
 Content-Type: application/json
 
 {
-    "project_dir": "{{project_name}}"
+    "project": "{{project_name}}"
 }
 
 ###
@@ -26,8 +26,6 @@ Content-Type: application/json
 GET http://{{host}}/spec
 
 ###
-
-@project_name = erp
 
 # @name getmappings
 GET http://{{host}}/mappings

--- a/server.py
+++ b/server.py
@@ -43,7 +43,6 @@ def create_app(projects_dir: Path):
         print("Loading project")
         # Get the project directory from the request
         data = request.get_json()
-        print(data)
         project_dir_name = data.get('project')
         if project_dir_name:
             project_dir = projects_dir / project_dir_name


### PR DESCRIPTION
Hier ein PR der das laden der Projekte mit in die Benutzerführung integriert. Langfristig nicht der beste Ansatz. Der Druck wird größer, dass wir auf eine DB wechseln und alle Zugriffe per REST Calls abfackeln können. Z.b.  {baseUrl}/project/{project_id}/mapping/{mapping_id} und das "laden" durch direkte Calls an die DB abgeloöst wird.

Bis dahin also der Versuch dieser Krücke:

https://github.com/SvenSommer/structure_comparer/pull/27